### PR TITLE
SAC-13 & SAC-14

### DIFF
--- a/src/Simplic.FileStructure.UI/FieldTypeEditor.xaml
+++ b/src/Simplic.FileStructure.UI/FieldTypeEditor.xaml
@@ -13,6 +13,11 @@
             <RowDefinition Height="auto"/>
             <RowDefinition Height="auto"/>
             <RowDefinition Height="auto"/>
+            <RowDefinition Height="25"/>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="auto" />
@@ -22,13 +27,19 @@
         <Label Grid.Row="0" Grid.Column="0" Content="{simplic:Localization Key=filestructure_dirfieldtype_name}" />
         <simplic:TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-        <Label Grid.Row="1" Grid.Column="0" Content="{simplic:Localization Key=filestructure_dirfieldtype_datatype}" />
-        <ComboBox Grid.Row="1" Grid.Column="1" SelectedValue="{Binding Datatype, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag">
+        <Label Grid.Row="1" Grid.Column="0" Content="{simplic:Localization Key=filestructure_dirfieldtype_internalname}" />
+        <simplic:TextBox Grid.Row="1" Grid.Column="1" Text="{Binding InternalName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+        <Label Grid.Row="2" Grid.Column="0" Content="{simplic:Localization Key=filestructure_dirfieldtype_datatype}" />
+        <ComboBox Grid.Row="2" Grid.Column="2" SelectedValue="{Binding Datatype, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag">
             <ComboBoxItem Content="Text" Tag="string" IsSelected="True"/>
             <ComboBoxItem Content="Nummer" Tag="int" />
             <ComboBoxItem Content="Datum" Tag="DateTime" />
             <ComboBoxItem Content="Boolean" Tag="bool" />
         </ComboBox>
-        
+
+        <Label Grid.Row="4" Grid.Column="0" Content="{simplic:Localization Key=filestructure_dirfieldtype_description}" />
+        <TextBox Grid.Row="5" Grid.RowSpan="3" Grid.ColumnSpan="2" Text="{Binding Description, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" TextWrapping="Wrap" AcceptsReturn="True" MinHeight="51" />
+
     </Grid>
 </local:BaseFieldTypeEditor>

--- a/src/Simplic.FileStructure.UI/ViewModel/FieldTypeEditorViewModel.cs
+++ b/src/Simplic.FileStructure.UI/ViewModel/FieldTypeEditorViewModel.cs
@@ -58,6 +58,22 @@ namespace Simplic.FileStructure.UI
             }
         }
 
+
+        /// <summary>
+        /// Gets or sets the internal name
+        /// </summary>
+        public string InternalName
+        {
+            get
+            {
+                return model.InternalName;
+            }
+            set
+            {
+                PropertySetter(value, (newValue) => { model.InternalName = newValue; });
+            }
+        }
+
         /// <summary>
         /// Gets or sets the datatype
         /// </summary>
@@ -72,5 +88,21 @@ namespace Simplic.FileStructure.UI
                 PropertySetter(value, (newValue) => { model.Datatype = newValue; });
             }
         }
+
+        /// <summary>
+        /// Gets or sets the description
+        /// </summary>
+        public string Description
+        {
+            get
+            {
+                return model.Description;
+            }
+            set
+            {
+                PropertySetter(value, (newValue) => { model.Description = newValue; });
+            }
+        }
+
     }
 }

--- a/src/Simplic.FileStructure/Model/FieldType.cs
+++ b/src/Simplic.FileStructure/Model/FieldType.cs
@@ -33,5 +33,23 @@ namespace Simplic.FileStructure
             get;
             set;
         }
+
+        /// <summary>
+        /// Gets or sets the field Description
+        /// </summary>
+        public string Description
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the field Internal Name
+        /// </summary>
+        public string InternalName
+        {
+            get;
+            set;
+        }
     }
 }


### PR DESCRIPTION
Added Description field and Internal name field for Field Definition

SAC-14
ALTER TABLE Admin.FileStructure_FieldType ADD Description AS VARCHAR(1000) NOT NULL DEFAULT ''

SAC-13
ALTER TABLE Admin.FileStructure_FieldType ADD InternalName AS VARCHAR(255) NOT NULL DEFAULT ''

I'm not sure if I did the export correctly. I went to Products, and used the existing f_metadata, added a new version (1.0.0.1), went to Grids, set the Grid Export for "GRID_FileStructure_FieldDefinition" to 1.0.0.1.
Then I created a deployment file.

[DCEF.zip](https://github.com/simplic/simplic-filestructure/files/3365312/DCEF.zip)

