### PR TITLE
SAC-15

### DIFF
--- a/src/Simplic.FileStructure.UI/DirectoryTypeEditor.xaml
+++ b/src/Simplic.FileStructure.UI/DirectoryTypeEditor.xaml
@@ -15,6 +15,7 @@
             <RowDefinition Height="auto"/>
             <RowDefinition Height="auto"/>
             <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -28,12 +29,15 @@
         <Label Grid.Row="1" Grid.Column="0" Content="{simplic:Localization Key=filestructure_dirtype_icon}" />
         <simplic:IconLookupTextBox Grid.Row="1" Grid.Column="1" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" SelectedIcon="{Binding IconId, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" />
 
-        <simplic:CheckBox Grid.Row="2" Grid.Column="1" Content="{simplic:Localization Key=filestructure_dirtype_drag}" IsChecked="{Binding EnableDrag, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        <Label Grid.Row="2" Grid.Column="0" Content="{simplic:Localization Key=filestructure_dirtype_category}" />
+        <simplic:TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Category, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        
+        <simplic:CheckBox Grid.Row="3" Grid.Column="1" Content="{simplic:Localization Key=filestructure_dirtype_drag}" IsChecked="{Binding EnableDrag, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-        <simplic:CheckBox Grid.Row="3" Grid.Column="1" Content="{simplic:Localization Key=filestructure_dirtype_drop}" IsChecked="{Binding EnableDrop, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        <simplic:CheckBox Grid.Row="4" Grid.Column="1" Content="{simplic:Localization Key=filestructure_dirtype_drop}" IsChecked="{Binding EnableDrop, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-        <Label Grid.Row="4" Grid.ColumnSpan="2" Content="{simplic:Localization Key=filestructure_dirfields}" />
-        <Grid Grid.Row="5" Grid.ColumnSpan="2" MinWidth="300">
+        <Label Grid.Row="5" Grid.ColumnSpan="2" Content="{simplic:Localization Key=filestructure_dirfields}" />
+        <Grid Grid.Row="6" Grid.ColumnSpan="2" MinWidth="300">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="50*" />
                 <ColumnDefinition Width="75"/>

--- a/src/Simplic.FileStructure.UI/FileStructureControl.xaml
+++ b/src/Simplic.FileStructure.UI/FileStructureControl.xaml
@@ -57,7 +57,7 @@
                              PreviewMouseDown="TreeViewMouseDown"
                              MouseDoubleClick="OnTreeViewMouseDoubleClick">
                     <telerik:RadContextMenu.ContextMenu>
-                        <telerik:RadContextMenu x:Name="treeViewContextMenu">
+                        <telerik:RadContextMenu>
                             <telerik:RadMenuGroupItem x:Name="contextMenuAddDirectories" ItemsSource="{Binding DirectoryCategoryMenuItems}">
                             </telerik:RadMenuGroupItem>
                             <telerik:RadMenuItem Header="{simplic:Localization Key=filestructure_remove_directory}" Command="{Binding RemoveDirectoryCommand}">

--- a/src/Simplic.FileStructure.UI/FileStructureControl.xaml
+++ b/src/Simplic.FileStructure.UI/FileStructureControl.xaml
@@ -57,12 +57,9 @@
                              PreviewMouseDown="TreeViewMouseDown"
                              MouseDoubleClick="OnTreeViewMouseDoubleClick">
                     <telerik:RadContextMenu.ContextMenu>
-                        <telerik:RadContextMenu>
-                            <telerik:RadMenuItem Header="{simplic:Localization Key=filestructure_add_directory}" ItemsSource="{Binding DirectoryTypeMenuItems}">
-                                <telerik:RadMenuItem.Icon>
-                                    <Image Height="16" Width="16" Source="{simplic:Icon Name=directory_add_x16}" />
-                                </telerik:RadMenuItem.Icon>
-                            </telerik:RadMenuItem>
+                        <telerik:RadContextMenu x:Name="treeViewContextMenu">
+                            <telerik:RadMenuGroupItem x:Name="contextMenuAddDirectories" ItemsSource="{Binding DirectoryCategoryMenuItems}">
+                            </telerik:RadMenuGroupItem>
                             <telerik:RadMenuItem Header="{simplic:Localization Key=filestructure_remove_directory}" Command="{Binding RemoveDirectoryCommand}">
                                 <telerik:RadMenuItem.Icon>
                                     <Image Height="16" Width="16" Source="{simplic:Icon Name=directory_remove_x16}" />

--- a/src/Simplic.FileStructure.UI/FileStructureControl.xaml
+++ b/src/Simplic.FileStructure.UI/FileStructureControl.xaml
@@ -58,7 +58,7 @@
                              MouseDoubleClick="OnTreeViewMouseDoubleClick">
                     <telerik:RadContextMenu.ContextMenu>
                         <telerik:RadContextMenu>
-                            <telerik:RadMenuGroupItem x:Name="contextMenuAddDirectories" ItemsSource="{Binding DirectoryCategoryMenuItems}">
+                            <telerik:RadMenuGroupItem ItemsSource="{Binding DirectoryCategoryMenuItems}">
                             </telerik:RadMenuGroupItem>
                             <telerik:RadMenuItem Header="{simplic:Localization Key=filestructure_remove_directory}" Command="{Binding RemoveDirectoryCommand}">
                                 <telerik:RadMenuItem.Icon>

--- a/src/Simplic.FileStructure.UI/ViewModel/DirectoryTypeEditorViewModel.cs
+++ b/src/Simplic.FileStructure.UI/ViewModel/DirectoryTypeEditorViewModel.cs
@@ -80,6 +80,21 @@ namespace Simplic.FileStructure.UI
         }
 
         /// <summary>
+        /// Gets or sets the type category
+        /// </summary>
+        public string Category
+        {
+            get
+            {
+                return model.Category;
+            }
+            set
+            {
+                PropertySetter(value, (newValue) => { model.Category = newValue; });
+            }
+        }
+
+        /// <summary>
         /// Gets or sets whether drag/drop is enabled
         /// </summary>
         public bool EnableDrag

--- a/src/Simplic.FileStructure.UI/ViewModel/FileStructureViewModel.cs
+++ b/src/Simplic.FileStructure.UI/ViewModel/FileStructureViewModel.cs
@@ -20,7 +20,7 @@ namespace Simplic.FileStructure.UI
     public class FileStructureViewModel : ExtendableViewModel, Studio.UI.IWindowViewModel<FileStructure>, IDirectoryBaseViewModel
     {
         private ObservableCollection<DirectoryViewModel> directories;
-        private ObservableCollection<RadMenuItem> directoryTypeMenuItems;
+        private ObservableCollection<RadMenuItem> directoryCategoryMenuItems;
         private IList<DirectoryViewModel> rawDirectories;
 
         private DirectoryViewModel selectedDirectory;
@@ -63,23 +63,40 @@ namespace Simplic.FileStructure.UI
             rootPath = "";
             VisualPathElements = new ObservableCollection<FrameworkElement>();
 
-            directoryTypeMenuItems = new ObservableCollection<RadMenuItem>();
-            foreach (var type in directoryTypeService.GetAll())
+            directoryCategoryMenuItems = new ObservableCollection<RadMenuItem>();
+
+            foreach (var category in directoryTypeService.GetAll().OrderBy(d => d.Category).GroupBy(d => d.Category))
             {
-                var menuItem = new RadMenuItem
+                var categoryItem = new RadMenuItem
                 {
-                    Header = localizationService.Translate(type.Name),
+                    Header = category.Key,
+                    Tag = category.Key,
                     Icon = new Image
                     {
-                        Source = iconService.GetByIdAsImage(type.IconId),
+                        Source = iconService.GetByNameAsImage("directory_add_x16"),
                         Width = 16,
                         Height = 16
-                    },
-                    Tag = type
+                    }
                 };
 
-                directoryTypeMenuItems.Add(menuItem);
-                menuItem.Click += AddDirectoryItemClick;
+                foreach (var type in category)
+                {
+                    var menuItem = new RadMenuItem
+                    {
+                        Header = localizationService.Translate(type.Name),
+                        Icon = new Image
+                        {
+                            Source = iconService.GetByIdAsImage(type.IconId),
+                            Width = 16,
+                            Height = 16
+                        },
+                        Tag = type
+                    };
+                    menuItem.Click += AddDirectoryItemClick;
+                    categoryItem.Items.Add(menuItem);
+                }
+
+                directoryCategoryMenuItems.Add(categoryItem);
             }
 
             // Create remove directory command
@@ -599,16 +616,16 @@ namespace Simplic.FileStructure.UI
             }
         }
 
-        public ObservableCollection<RadMenuItem> DirectoryTypeMenuItems
+        public ObservableCollection<RadMenuItem> DirectoryCategoryMenuItems
         {
             get
             {
-                return directoryTypeMenuItems;
+                return directoryCategoryMenuItems;
             }
 
             set
             {
-                directoryTypeMenuItems = value;
+                directoryCategoryMenuItems = value;
             }
         }
 

--- a/src/Simplic.FileStructure/Model/DirectoryType.cs
+++ b/src/Simplic.FileStructure/Model/DirectoryType.cs
@@ -38,6 +38,15 @@ namespace Simplic.FileStructure
         }
 
         /// <summary>
+        /// Gets or sets the type category
+        /// </summary>
+        public string Category
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Gets or sets whether drag/drop is enabled
         /// </summary>
         public bool EnableDrag


### PR DESCRIPTION
Assign directory types a category string, new directories are put as a subitem to these categories.

ALTER TABLE Admin.FileStructure_DirectoryType ADD Category AS VARCHAR(255) NOT NULL DEFAULT 'Sonstiges'

[f_createDirectorySubCategories_v1.0.0.0.zip](https://github.com/simplic/simplic-filestructure/files/3365388/f_createDirectorySubCategories_v1.0.0.0.zip)
