### PR TITLE
Fixes a bug, when resoving th workflow-state is done before adding a …

### DIFF
--- a/release-notes.xml
+++ b/release-notes.xml
@@ -29,4 +29,8 @@
   <Change type="bug">
     Fixes a bug when resolving worklow state-provider.
   </Change>
+  <Change type="bug">
+    Fixes a bug, when resoving th workflow-state is done before adding a document to the workflow. This prevents from being set to "completed",
+    if they are still in an organization unit.
+  </Change>
 </ReleaseNotes>

--- a/src/Simplic.FileStructure.Service/FileStructureDocumentPathService.cs
+++ b/src/Simplic.FileStructure.Service/FileStructureDocumentPathService.cs
@@ -141,11 +141,11 @@ namespace Simplic.FileStructure.Service
 						if (workflow == null) throw new Exception($"Could not find workflow: {workflowId}");
 
 						var stateProvider = unityContainer.Resolve<IDocumentWorkflowStateProvider>(workflow.StateProviderName);
+						var state = stateProvider.ResolveDocumentWorkflowState(obj.DocumentGuid, workflowId);
+						if (state == null) throw new Exception($"Could not resolve initial state for document: {obj.DocumentGuid}");
 
 						if (!documentWorkflowAssignmentService.Exists(obj.DocumentGuid, workflowId))
 						{
-							var state = stateProvider.ResolveDocumentWorkflowState(obj.DocumentGuid, workflowId);
-							if (state == null) throw new Exception($"Could not resolve initial state for document: {obj.DocumentGuid}");
 
 							var assignment = new DocumentWorkflowAssignment
 							{
@@ -158,9 +158,6 @@ namespace Simplic.FileStructure.Service
 						}
 						else
 						{
-							var state = stateProvider.ResolveDocumentWorkflowState(obj.DocumentGuid, workflowId);
-							if (state == null) throw new Exception($"Could not resolve initial state for document: {obj.DocumentGuid}");
-
 							documentWorkflowAssignmentService.SetState(obj.DocumentGuid, workflowId, state.Guid);
 						}
 					}

--- a/src/Simplic.FileStructure.Workflow.Service/WorkflowOperationService.cs
+++ b/src/Simplic.FileStructure.Workflow.Service/WorkflowOperationService.cs
@@ -240,13 +240,6 @@ namespace Simplic.FileStructure.Workflow.Service
         private void SaveWorkflowOrganizationUnitAssignment(WorkflowOperation workflowOperation, string stateProvider)
         {
             var documentWorkflowStateProvider = unityContainer.Resolve<IDocumentWorkflowStateProvider>(stateProvider);
-            var state = documentWorkflowStateProvider.ResolveDocumentWorkflowState(workflowOperation.DocumentId, workflowOperation.WorkflowId);
-            documentWorkflowAssignmentService.Save(new DocumentWorkflowAssignment
-            {
-                DocumentId = workflowOperation.DocumentId,
-                StateId = state.Guid,
-                WorkflowId = workflowOperation.WorkflowId
-            });
 
             var documentWorkflowOrganzitionUnitAssignment = new DocumentWorkflowOrganizationUnitAssignment
             {
@@ -255,6 +248,14 @@ namespace Simplic.FileStructure.Workflow.Service
                 WorkflowId = workflowOperation.WorkflowId
             };
             documentWorkflowOrganizationUnitAssignmentService.Save(documentWorkflowOrganzitionUnitAssignment);
+
+            var state = documentWorkflowStateProvider.ResolveDocumentWorkflowState(workflowOperation.DocumentId, workflowOperation.WorkflowId);
+            documentWorkflowAssignmentService.Save(new DocumentWorkflowAssignment
+            {
+                DocumentId = workflowOperation.DocumentId,
+                StateId = state.Guid,
+                WorkflowId = workflowOperation.WorkflowId
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
…document to the workflow. This prevents from being set to "completed",

    if they are still in an organization unit.